### PR TITLE
Fix rear-core utilities listed in README.md

### DIFF
--- a/packages/rear-core/README.md
+++ b/packages/rear-core/README.md
@@ -7,7 +7,7 @@ A collection of development utilities for [Rear](https://github.com/rearjs/rear)
 ### Sync
 * [getRearEnv](docs/api/get-rear-env.md)
 * [RearError](docs/api/rear-error.md)
-* [runFlow](docs/api/run-lint.md)
+* [runLint](docs/api/run-lint.md)
 * [shouldUseYarn](docs/api/should-use-yarn.md)
 
 ### Async


### PR DESCRIPTION
Fix a typo in rear-core `README.md` where `runLint` utility was listed as `runFlow`.