### PR TITLE
Fix a rear-error issue with stack trace being captured before message

### DIFF
--- a/packages/rear-core/__tests__/rear-error.spec.js
+++ b/packages/rear-core/__tests__/rear-error.spec.js
@@ -1,18 +1,25 @@
 const RearError = require('../rear-error');
 
-it('Should have code, errno and other props', () => {
-  const errMessage = 'Test error message';
-  const errProps = {
-    code: 'ETEST',
-    errno: 400,
-    extras: ['rear-core', 'rear-logger']
-  };
-  const expectedErrProps = { extras: errProps.extras }
+describe('rear-error', () => {
+  it('Should have message, code, errno and other props', () => {
+    const message = 'Test error message';
+    const props = { code: 'ETEST', errno: 400, extras: ['rear-core'] };
+    const expectedProps = { extras: props.extras }
 
-  const err = new RearError(errMessage, errProps);
+    const err = new RearError(message, props);
 
-  expect(err.message).toBe(errMessage);
-  expect(err.code).toEqual(errProps.code);
-  expect(err.errno).toEqual(errProps.errno);
-  expect(err.props).toEqual(expectedErrProps);
-});
+    expect(err.message).toBe(message);
+    expect(err.code).toEqual(props.code);
+    expect(err.errno).toEqual(props.errno);
+    expect(err.props).toEqual(expectedProps);
+  });
+
+  it('Should include the error message in the stack trace', () => {
+    const message = 'Test error message';
+    const props = { code: 'ETEST', errno: 500 };
+    const err = new RearError(message, props);
+
+    expect(err.stack).toBeDefined();
+    expect(err.stack.split('\n')[0].indexOf(message) !== -1).toBeTruthy();
+  });
+})

--- a/packages/rear-core/rear-error.js
+++ b/packages/rear-core/rear-error.js
@@ -1,9 +1,9 @@
 const util = require('util');
 
-function RearError(message, props) {
-  Error.captureStackTrace(this, this.constructor);
+function RearError (message, props) {
   this.name = this.constructor.name;
   this.message = message;
+  Error.captureStackTrace(this, this.constructor);
   this.props = Object.assign({}, props);
 
   if (this.props.hasOwnProperty('code')) {


### PR DESCRIPTION
Since Error's stack trace was captured before the Error's message was set in the constructor, the resulting stack trace being printed in the console was lacking an error message.