### PR TITLE
Fix an issue with runtime-require when rear-core module is simlinked

### DIFF
--- a/packages/rear-core/__tests__/resolve-app.spec.js
+++ b/packages/rear-core/__tests__/resolve-app.spec.js
@@ -1,6 +1,13 @@
 const resolveApp = require('../resolve-app');
 
-it('should resolve path from app', () => {
-  const thisFile = resolveApp('./__tests__/resolve-app.spec.js');
-  expect(thisFile).toBe(__filename);
+describe('resolve-app', () => {
+  it('Should resolve path from app', () => {
+    const thisFile = resolveApp('./__tests__/resolve-app.spec.js');
+    expect(thisFile).toBe(__filename);
+  });
+
+  it('Should join multiple paths before resolving', () => {
+    const thisFile = resolveApp('./__tests__/', 'resolve-app.spec.js');
+    expect(thisFile).toBe(__filename);
+  });
 });

--- a/packages/rear-core/__tests__/runtime-require.spec.js
+++ b/packages/rear-core/__tests__/runtime-require.spec.js
@@ -1,0 +1,14 @@
+const runtimeRequire = require('../runtime-require');
+
+it('Should throw RuntimeModuleNotFound for non existing modules', () => {
+  try {
+    const nonExistentModule = runtimeRequire('test-module', __filename);
+  } catch (err) {
+    expect(err.constructor.name).toEqual('RuntimeModuleNotFound');
+  }
+});
+
+it('Should successfully require existent module', () => {
+  const path = runtimeRequire('path', __filename);
+  expect(path).toBeDefined();
+});

--- a/packages/rear-core/docs/api/resolve-app.md
+++ b/packages/rear-core/docs/api/resolve-app.md
@@ -1,0 +1,37 @@
+# resolve-app
+
+Use `resolve-app` to resolve any path relative to the current location as an
+absolute path. This is especially useful in scripts were you need to access
+files relative to the user current working directory.
+
+## Example
+
+  ```javascript
+  const fs = require('fs');
+  const resolveApp = require('rear-core/resolve-app');
+  const ownPackageJson = resolveApp('package.json');
+
+  // creates a local "package.json" file
+  fs.writeFileSync(ownPackageJson, JSON.stringify({
+    name: 'my-awesome-app',
+    version: '0.1.0',
+    private: true
+  }));
+  ```
+
+## API
+
+#### resolveApp (...paths: <string>): string
+
+Resolve a relative path as absolute. If more than one path is passed, they will
+be joined using `path.join`.
+
+##### Arguments
+
+| Argument | Type     | Description                 |
+|----------|----------|-----------------------------|
+| ...paths | <string> | A sequence of path segments |
+
+##### Returns
+
+`string` An absolute path from joined `paths` relative to the current directory

--- a/packages/rear-core/resolve-app.js
+++ b/packages/rear-core/resolve-app.js
@@ -3,4 +3,4 @@ const path = require('path');
 
 // Resolve path relative to current working directory
 const appDirectory = fs.realpathSync(process.cwd());
-module.exports = (relativePath) => path.resolve(appDirectory, relativePath);
+module.exports = (...args) => path.resolve(appDirectory, path.join(...args));

--- a/packages/rear-core/runtime-require.js
+++ b/packages/rear-core/runtime-require.js
@@ -1,3 +1,5 @@
+const fs = require('fs');
+const resolveApp = require('./resolve-app');
 const {RuntimeModuleNotFound} = require('./errors');
 
 module.exports = runtimeRequire;
@@ -6,6 +8,8 @@ module.exports = runtimeRequire;
 
 function runtimeRequire (moduleName, realm) {
   try {
+    const ownModule = resolveApp('node_modules', moduleName);
+    if (fs.existsSync(ownModule)) moduleName = ownModule;
     return require(moduleName);
   } catch (err) {
     if ('MODULE_NOT_FOUND' === err.code) {


### PR DESCRIPTION
When `rear-core` is is installed through `lerna bootstrap` the module is simlinked in `node_modules`, causing `runtime-require` to walkup its parent module tree, in search of the required module, inside `rear-core` instead of the local `node_modules`. 

To solve this issue now `runtime-require` first check for the module presence in the current working directory and then tries to walkup the tree.